### PR TITLE
Feature: Support float type and "in" expressions

### DIFF
--- a/spec/data_tables/search_spec.rb
+++ b/spec/data_tables/search_spec.rb
@@ -25,6 +25,13 @@ describe DataTables::Modules::Search do
           "searchable": true,
           "orderable": true,
           "search": { "value": "", "regex": false }
+        },
+        {
+          "data": "engagement_rate",
+          "name": "",
+          "searchable": true,
+          "orderable": true,
+          "search": { "value": "", "regex": false }
         }
       ],
       "draw": 3,
@@ -43,8 +50,9 @@ describe DataTables::Modules::Search do
     before(:each) do
       User.create(email: 'foo@bar.com')
       User.create(email: 'foo2@bar.com')
-      Post.create(title: 'foo', views: 4)
-      Post.create(title: 'bar', views: 3)
+      Post.create(title: 'foo', views: 4, engagement_rate: 0.5)
+      Post.create(title: 'bar', views: 3, engagement_rate: 1.0)
+      Post.create(title: 'baz', views: 2, engagement_rate: 2.0)
     end
 
     it 'integers' do
@@ -58,9 +66,54 @@ describe DataTables::Modules::Search do
 
       posts = dt_module.search
 
-      # expect{dt_module.search}.to_not raise_error()
       expect(posts.count).to eq(1)
       expect(posts[0].views).to eq(4)
+
+    end
+
+    it 'integers for any of many values' do
+
+      complex_params[:columns][2][:search] = {
+        "value": ["4", "3", "1"],
+        "regex": false
+      }
+
+      dt_module = DataTables::Modules::Search.new(Post, Post.all, complex_params)
+
+      posts = dt_module.search
+
+      expect(posts.count).to eq(2)
+
+    end
+
+    it 'floats' do
+
+      complex_params[:columns][3][:search] = {
+        "value": ".5",
+        "regex": false
+      }
+
+      dt_module = DataTables::Modules::Search.new(Post, Post.all, complex_params)
+
+      posts = dt_module.search
+
+      expect(posts.count).to eq(1)
+      expect(posts[0].views).to eq(4)
+
+    end
+
+    it 'floats for any of many values' do
+
+      complex_params[:columns][3][:search] = {
+        "value": ["1", ".5", "1.5"],
+        "regex": false
+      }
+
+      dt_module = DataTables::Modules::Search.new(Post, Post.all, complex_params)
+
+      posts = dt_module.search
+
+      expect(posts.count).to eq(2)
 
     end
 
@@ -75,9 +128,23 @@ describe DataTables::Modules::Search do
 
       posts = dt_module.search
 
-      # expect{dt_module.search}.to_not raise_error()
       expect(posts.count).to eq(1)
       expect(posts[0].title).to eq('foo')
+
+    end
+
+    it 'strings for any of many values' do
+
+      complex_params[:columns][1][:search] = {
+        "value": ["foo", "bar"],
+        "regex": false
+      }
+
+      dt_module = DataTables::Modules::Search.new(Post, Post.all, complex_params)
+
+      posts = dt_module.search
+
+      expect(posts.count).to eq(2)
 
     end
 
@@ -92,7 +159,6 @@ describe DataTables::Modules::Search do
 
       users = dt_module.search
 
-      # expect{dt_module.search}.to_not raise_error()
       expect(users.count).to eq(1)
       expect(users[0].email).to eq('foo@bar.com')
 

--- a/spec/support/rails/db/schema.rb
+++ b/spec/support/rails/db/schema.rb
@@ -12,7 +12,8 @@ ActiveRecord::Schema.define do
   create_table :posts, :force => true do |t|
     t.uuid :user_id
     t.string :title
-    t.integer :views # for testing integers
+    t.integer :views
+    t.float :engagement_rate
     t.timestamps
   end
 


### PR DESCRIPTION
Search module now supports float type and in expressions ( Model.where field: [...] ) for float, integer, and string.